### PR TITLE
audit: comprehensive hygiene, bug fixes, and new features

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,147 @@
+# Copilot instructions — FanOut
+
+This file gives targeted, repository-specific guidance for future Copilot sessions working on FanOut (Go, single-binary HTTP fan-out service).
+
+---
+
+## Build, test, and lint commands
+
+Build (release):
+
+    go build -trimpath -ldflags="-w -s" -o fanout
+
+Build (debug):
+
+    go build -tags=debug -o fanout-debug
+
+Run locally (echo mode for development):
+
+    TARGETS=localonly go run fanout.go
+
+Run with production targets:
+
+    TARGETS="https://a.example/,https://b.example/" PORT=8080 go run fanout.go
+
+Run the full test suite (with race detector):
+
+    go test -v -race ./...
+
+Run a single test (exact name):
+
+    go test -run '^TestSendRequest$' .
+
+Run a single test with race and verbose output:
+
+    go test -run '^TestSendRequest$' -v -race .
+
+Formatting / vet:
+
+    gofmt -w .
+    go vet ./...
+
+Security scan (used by README/CI):
+
+    gosec ./...
+
+Docker (local):
+
+    docker build -t fanout:dev .
+
+Multi-arch build (CI / release):
+
+    docker buildx build --platform linux/amd64,linux/arm64 -t yourorg/fanout:latest .
+
+CI workflows:
+
+- .github/workflows/docker-image.yml
+- .github/workflows/binary-release.yml
+
+---
+
+## High-level architecture (big picture)
+
+- Entrypoint: `fanout.go` — sets up HTTP handlers and environment-based configuration in `init()`.
+
+- Endpoints:
+  - `ENDPOINT_PATH` (default `/fanout`) — main fan-out endpoint.
+  - `/health` — simple health check.
+  - `/version` — binary/version metadata.
+  - `/metrics` — Prometheus handler (enabled when `METRICS_ENABLED=true`).
+
+- Modes:
+  - Echo mode: `TARGETS=localonly` — inbound requests are echoed back by `echoHandler`.
+  - Multiplex mode: `TARGETS` contains comma-separated targets; `multiplex` spawns one goroutine per target.
+
+- Dispatcher & concurrency:
+  - `multiplex` launches a goroutine per configured target; responses are collected via a buffered channel and WaitGroup. Response order is not guaranteed.
+
+- Request forwarding (`sendRequest`):
+  - Re-creates the original request per target, clones headers via `cloneHeaders` (sensitive headers are logged), and sets Content-Length appropriately.
+  - Implements retries for network errors and server (5xx) responses using exponential backoff + jitter.
+  - Adds `X-Retry-Count` on retry attempts.
+
+- Logging & metrics:
+  - Asynchronous logger: `logQueue` is a buffered channel, format controlled by `LOG_FORMAT` (json/text) and `LOG_LEVEL`.
+  - Prometheus metrics (prefixed `fanout_`) are recorded when `METRICS_ENABLED=true`.
+
+---
+
+## Key repository conventions and gotchas
+
+- Configuration is environment-driven and read in `init()`; changing env vars requires restarting the process.
+
+- Body handling / GetBody semantics:
+  - The code uses a pre-read body optimization: when available, `preReadBody` is used for the first attempt; subsequent attempts call `getBody()`.
+  - Tests use `httptest.NewRequest` which provides `GetBody`; when writing tests or mock requests, ensure `GetBody` is present or provide a pre-read body.
+
+- Retry behavior:
+  - Controlled via `MAX_RETRIES` (default: 3).
+  - Network errors are detected by substring matching in `isRetryableError` (e.g., "connection refused", "timeout", "deadline exceeded", "connection reset", "no such host").
+  - 5xx responses trigger retries up to the configured limit.
+
+- Sensitive headers:
+  - Configured via `SENSITIVE_HEADERS` (default `Authorization,Cookie`). `cloneHeaders` will log a warning when those are detected.
+
+- Metrics naming and labels:
+  - Prometheus metrics use fixed names (e.g., `fanout_requests_total`, `fanout_target_requests_total`). Avoid renaming these without updating monitoring.
+
+- Concurrency expectations:
+  - `multiplex` returns responses as they arrive. Do not rely on responses being in the same order as `TARGETS` unless ordering is explicitly implemented.
+
+- Logging behavior:
+  - Log entries are queued to `logQueue`; if the queue is full, entries may be dropped or logged directly when errors occur.
+
+- Versioning variables:
+  - `Version`, `GitCommit`, and `BuildTime` are populated at build time (defaults: dev/unknown). CI/release workflows set these.
+
+---
+
+## Where to look (short pointers)
+
+- Core: `fanout.go` (single-file service implementation)
+- Unit tests: `fanout_test.go`
+- Container: `Dockerfile`, `compose.yml`
+- CI: `.github/workflows/*`
+
+---
+
+## Repository workflow preferences
+
+- Docker-only execution: All development, builds, tests and linters should be executed inside Docker containers, not on the host machine. This includes local runs, single-test runs, formatting, vetting, and CI-parity commands. Examples:
+
+    # Run full test suite inside official Go container
+    docker run --rm -v $(pwd):/src -w /src golang:1.24 go test -v -race ./...
+
+    # Run a single test inside Docker
+    docker run --rm -v $(pwd):/src -w /src golang:1.24 go test -run '^TestSendRequest$' -v -race .
+
+    # Build inside Docker
+    docker run --rm -v $(pwd):/src -w /src golang:1.24 go build -trimpath -ldflags="-w -s" -o fanout
+
+  Prefer running via docker-compose (compose.yml) or CI-style containers so host toolchains are not required.
+
+- Atomic commits: Make small, atomic commits for every logical change. Each commit should be self-contained and reversible. Use a separate branch per feature/bugfix and keep commit messages focused on a single purpose.
+
+---
+
+If something important is missing or you want additional coverage (examples, more test-run tips, or CI notes), ask and this file can be expanded.

--- a/.github/workflows/binary-release.yml
+++ b/.github/workflows/binary-release.yml
@@ -37,7 +37,11 @@ jobs:
         run: |
           go mod download
           go test -v ./...
-        
+
+      - name: Security scan (gosec)
+        run: |
+          docker run --rm -v ${{ github.workspace }}:/src -w /src securego/gosec:latest gosec ./...
+
       - name: Build for multiple platforms
         run: |
           mkdir -p dist

--- a/.github/workflows/binary-release.yml
+++ b/.github/workflows/binary-release.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Security scan (gosec)
         run: |
-          docker run --rm -v ${{ github.workspace }}:/src -w /src securego/gosec:latest gosec ./...
+          docker run --rm -v ${{ github.workspace }}:/src -w /src securego/gosec:v2.22.4 gosec ./...
 
       - name: Build for multiple platforms
         run: |

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -55,7 +55,8 @@ jobs:
 
       - name: Static analysis (gofmt, go vet)
         run: |
-          docker run --rm -v ${{ github.workspace }}:/src -w /src golang:1.24 sh -c "gofmt -l . || true; go vet ./... || true"
+          docker run --rm -v ${{ github.workspace }}:/src -w /src golang:1.24 sh -c \
+            'GOFMT_OUT=$(gofmt -l .); [ -z "$GOFMT_OUT" ] || (echo "$GOFMT_OUT"; exit 1); go vet ./...'
 
       - name: Security scan (gosec)
         run: |

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -60,7 +60,7 @@ jobs:
 
       - name: Security scan (gosec)
         run: |
-          docker run --rm -v ${{ github.workspace }}:/src -w /src securego/gosec:latest gosec ./...
+          docker run --rm -v ${{ github.workspace }}:/src -w /src securego/gosec:v2.22.4 gosec ./...
 
       - name: Run unit tests (inside Docker)
         run: |

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -53,10 +53,17 @@ jobs:
         with:
           go-version: '1.24'
 
-      - name: Run unit tests
+      - name: Static analysis (gofmt, go vet)
         run: |
-          go mod download
-          go test -v ./...
+          docker run --rm -v ${{ github.workspace }}:/src -w /src golang:1.24 sh -c "gofmt -l . || true; go vet ./... || true"
+
+      - name: Security scan (gosec)
+        run: |
+          docker run --rm -v ${{ github.workspace }}:/src -w /src securego/gosec:latest gosec ./...
+
+      - name: Run unit tests (inside Docker)
+        run: |
+          docker run --rm -v ${{ github.workspace }}:/src -w /src golang:1.24 go test -v -race ./...
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3

--- a/fanout.go
+++ b/fanout.go
@@ -7,11 +7,14 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log"
 	"math/rand"
+	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"strconv"
 	"strings"
@@ -404,7 +407,29 @@ func multiplex(w http.ResponseWriter, r *http.Request) {
 
 	var bodyBytes []byte
 	var readErr error
-	if r.ContentLength <= 0 {
+
+	// If GetBody is not available (e.g., streaming request), pre-read the body
+	// into memory up to maxBodySize so retries can recreate the body safely.
+	if getBody == nil {
+		bodyBytes, readErr = io.ReadAll(io.LimitReader(r.Body, maxBodySize+1))
+		r.Body.Close()
+		if readErr != nil {
+			logError("Error reading request body: %v", readErr)
+			writeJSONError(w, "Failed to read request body", http.StatusBadRequest)
+			return
+		}
+		if int64(len(bodyBytes)) > maxBodySize {
+			logError("Request body size exceeds limit (%d bytes read)", len(bodyBytes))
+			writeJSONError(w, "Payload too large", http.StatusRequestEntityTooLarge)
+			return
+		}
+
+		// Provide a GetBody closure for retries
+		getBody = func() (io.ReadCloser, error) {
+			return io.NopCloser(bytes.NewReader(bodyBytes)), nil
+		}
+	} else if r.ContentLength <= 0 {
+		// When ContentLength is unknown but GetBody exists, use it to perform a size check
 		bodyReader, err := getBody()
 		if err != nil {
 			logError("Failed to get request body reader: %v", err)
@@ -633,8 +658,31 @@ func isRetryableError(err error) bool {
 		return false
 	}
 
-	errMsg := strings.ToLower(err.Error())
+	// Prefer typed checks for net errors and url errors
+	var nerr net.Error
+	if errors.As(err, &nerr) {
+		if nerr.Timeout() || nerr.Temporary() {
+			return true
+		}
+	}
 
+	var ue *url.Error
+	if errors.As(err, &ue) {
+		// If the wrapped error is a net.Error with timeout/temporary, treat as retryable
+		var innerNetErr net.Error
+		if errors.As(ue.Err, &innerNetErr) {
+			if innerNetErr.Timeout() || innerNetErr.Temporary() {
+				return true
+			}
+		}
+		// Some url.Errors include "timeout" in the string; treat as retryable
+		if ue.Timeout() {
+			return true
+		}
+	}
+
+	// Fallback: substring matching for common transient messages
+	errMsg := strings.ToLower(err.Error())
 	if strings.Contains(errMsg, "connection refused") ||
 		strings.Contains(errMsg, "timeout") ||
 		strings.Contains(errMsg, "deadline exceeded") ||

--- a/fanout.go
+++ b/fanout.go
@@ -687,27 +687,16 @@ func isRetryableError(err error) bool {
 		return false
 	}
 
-	// Prefer typed checks for net errors and url errors
+	// Prefer typed checks for net errors and url errors.
+	// Note: net.Error.Temporary() is deprecated since Go 1.18 and intentionally omitted.
 	var nerr net.Error
-	if errors.As(err, &nerr) {
-		if nerr.Timeout() || nerr.Temporary() {
-			return true
-		}
+	if errors.As(err, &nerr) && nerr.Timeout() {
+		return true
 	}
 
 	var ue *url.Error
-	if errors.As(err, &ue) {
-		// If the wrapped error is a net.Error with timeout/temporary, treat as retryable
-		var innerNetErr net.Error
-		if errors.As(ue.Err, &innerNetErr) {
-			if innerNetErr.Timeout() || innerNetErr.Temporary() {
-				return true
-			}
-		}
-		// Some url.Errors include "timeout" in the string; treat as retryable
-		if ue.Timeout() {
-			return true
-		}
+	if errors.As(err, &ue) && ue.Timeout() {
+		return true
 	}
 
 	// Fallback: substring matching for common transient messages
@@ -730,18 +719,10 @@ func addJitter(d time.Duration) time.Duration {
 	return time.Duration(jitter)
 }
 
-func min(a, b time.Duration) time.Duration {
-	if a < b {
-		return a
-	}
-	return b
-}
-
 func writeJSON(w http.ResponseWriter, v interface{}) error {
 	encoder := json.NewEncoder(w)
 	encoder.SetEscapeHTML(false)
 	if err := encoder.Encode(v); err != nil {
-		w.WriteHeader(http.StatusInternalServerError)
 		logError("Error encoding JSON: %v", err)
 		return err
 	}

--- a/fanout.go
+++ b/fanout.go
@@ -193,12 +193,12 @@ func init() {
 	} else {
 		size, err := humanize.ParseBytes(sizeStr)
 		if err != nil {
-			log.Printf("Invalid MAX_BODY_SIZE '%s', using default: %v", sizeStr, err)
+			log.Printf("Invalid MAX_BODY_SIZE, using default: %v", sizeStr, err)
 			maxBodySize = defaultMaxBodySize
 		} else {
 			// humanize.ParseBytes returns uint64; guard against overflow when converting to int64
 			if size > uint64(^uint64(0)>>1) {
-				log.Printf("MAX_BODY_SIZE '%s' too large, capping to default: %d", sizeStr, defaultMaxBodySize)
+				log.Printf("MAX_BODY_SIZE too large, capping to default: %d", sizeStr, defaultMaxBodySize)
 				maxBodySize = defaultMaxBodySize
 			} else {
 				maxBodySize = int64(size)
@@ -208,7 +208,7 @@ func init() {
 
 	if timeout := os.Getenv("REQUEST_TIMEOUT"); timeout != "" {
 		if d, err := time.ParseDuration(timeout); err != nil {
-			log.Printf("Invalid REQUEST_TIMEOUT '%s', using default: %v", timeout, err)
+			log.Printf("Invalid REQUEST_TIMEOUT, using default: %v", timeout, err)
 			requestTimeout = defaultRequestTimeout
 		} else {
 			requestTimeout = d
@@ -219,7 +219,7 @@ func init() {
 
 	if timeout := os.Getenv("CLIENT_TIMEOUT"); timeout != "" {
 		if d, err := time.ParseDuration(timeout); err != nil {
-			log.Printf("Invalid CLIENT_TIMEOUT '%s', using default: %v", timeout, err)
+			log.Printf("Invalid CLIENT_TIMEOUT, using default: %v", timeout, err)
 			clientTimeout = defaultClientTimeout
 		} else {
 			clientTimeout = d
@@ -263,7 +263,7 @@ func init() {
 
 	if retriesStr := os.Getenv("MAX_RETRIES"); retriesStr != "" {
 		if retries, err := strconv.Atoi(retriesStr); err != nil || retries < 0 {
-			log.Printf("Invalid MAX_RETRIES '%s', using default: %v", retriesStr, err)
+			log.Printf("Invalid MAX_RETRIES, using default: %v", retriesStr, err)
 			maxRetries = defaultMaxRetries
 		} else {
 			maxRetries = retries
@@ -323,7 +323,8 @@ func logWithLevel(level int, context map[string]string, format string, args ...i
 	case logQueue <- entry:
 	default:
 		if level >= LogLevelError {
-			log.Printf("WARNING: Log queue full, logging ERROR directly: %s", entry.Message)
+			// Avoid logging untrusted message contents directly to prevent log injection (gosec G706)
+			log.Printf("WARNING: Log queue full, logging ERROR directly")
 		}
 	}
 }
@@ -360,10 +361,16 @@ func echoHandler(w http.ResponseWriter, r *http.Request) {
 	switch os.Getenv("ECHO_MODE_RESPONSE") {
 	case "full":
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(echoData)
+		if err := json.NewEncoder(w).Encode(echoData); err != nil {
+			logError("Failed to encode echo response: %v", err)
+			return
+		}
 	default:
 		w.WriteHeader(http.StatusAccepted)
-		json.NewEncoder(w).Encode(map[string]string{"status": "echoed"})
+		if err := json.NewEncoder(w).Encode(map[string]string{"status": "echoed"}); err != nil {
+			logError("Failed to encode echo short response: %v", err)
+			return
+		}
 	}
 
 	loggedBody := string(bodyBytes)
@@ -381,7 +388,9 @@ func echoHandler(w http.ResponseWriter, r *http.Request) {
 
 func healthCheck(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
-	json.NewEncoder(w).Encode(map[string]string{"status": "healthy"})
+	if err := json.NewEncoder(w).Encode(map[string]string{"status": "healthy"}); err != nil {
+		logError("Failed to encode health response: %v", err)
+	}
 }
 
 type Response struct {
@@ -418,7 +427,9 @@ func multiplex(w http.ResponseWriter, r *http.Request) {
 	// into memory up to maxBodySize so retries can recreate the body safely.
 	if getBody == nil {
 		bodyBytes, readErr = io.ReadAll(io.LimitReader(r.Body, maxBodySize+1))
-		r.Body.Close()
+			if err := r.Body.Close(); err != nil {
+				logWarn("Failed to close request body after read: %v", err)
+			}
 		if readErr != nil {
 			logError("Error reading request body: %v", readErr)
 			writeJSONError(w, "Failed to read request body", http.StatusBadRequest)
@@ -443,7 +454,9 @@ func multiplex(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		bodyBytes, readErr = io.ReadAll(io.LimitReader(bodyReader, maxBodySize+1))
-		bodyReader.Close()
+			if err := bodyReader.Close(); err != nil {
+				logWarn("Failed to close body reader after size check: %v", err)
+			}
 
 		if readErr != nil {
 			logError("Error reading body for size check: %v", readErr)

--- a/fanout.go
+++ b/fanout.go
@@ -16,6 +16,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -69,6 +70,13 @@ var (
 	endpointPath     string
 	metricsEnabled   bool
 	httpClient       *http.Client
+
+	// configuredTargets holds the parsed TARGETS list, populated at startup.
+	configuredTargets []string
+
+	// echoModeHeader and echoModeResponse cache ECHO_MODE_* env vars.
+	echoModeHeader   bool
+	echoModeResponse string
 
 	requestsTotal = promauto.NewCounterVec(
 		prometheus.CounterOpts{
@@ -167,6 +175,7 @@ func init() {
 						for k, v := range entry.Context {
 							parts = append(parts, fmt.Sprintf("%s=%s", k, v))
 						}
+						sort.Strings(parts)
 						contextStr = " " + strings.Join(parts, " ")
 					}
 					log.Printf("[%s]%s %s", entry.Level, contextStr, entry.Message)
@@ -272,7 +281,18 @@ func init() {
 		maxRetries = defaultMaxRetries
 	}
 
-	rand.Seed(time.Now().UnixNano())
+	// Cache TARGETS at startup to avoid per-request env reads.
+	if t := os.Getenv("TARGETS"); t != "" && t != "localonly" {
+		for _, u := range strings.Split(t, ",") {
+			if trimmed := strings.TrimSpace(u); trimmed != "" {
+				configuredTargets = append(configuredTargets, trimmed)
+			}
+		}
+	}
+
+	// Cache echo mode config.
+	echoModeHeader = strings.ToLower(os.Getenv("ECHO_MODE_HEADER")) == "true"
+	echoModeResponse = strings.ToLower(os.Getenv("ECHO_MODE_RESPONSE"))
 }
 
 func logDebug(format string, args ...interface{}) {
@@ -333,7 +353,7 @@ func cloneHeaders(original http.Header) http.Header {
 	cloned := make(http.Header)
 	for k, vv := range original {
 		if sensitiveHeaders[http.CanonicalHeaderKey(k)] {
-			logWarn("Sensitive header detected and propagated: %s", k)
+			logDebug("Sensitive header detected and forwarded: %s", k)
 		}
 		cloned[k] = vv
 	}
@@ -354,11 +374,11 @@ func echoHandler(w http.ResponseWriter, r *http.Request) {
 		"body":    string(bodyBytes),
 	}
 
-	if os.Getenv("ECHO_MODE_HEADER") == "true" {
+	if echoModeHeader {
 		w.Header().Set("X-Echo-Mode", "active")
 	}
 
-	switch os.Getenv("ECHO_MODE_RESPONSE") {
+	switch echoModeResponse {
 	case "full":
 		w.Header().Set("Content-Type", "application/json")
 		if err := json.NewEncoder(w).Encode(echoData); err != nil {
@@ -427,9 +447,9 @@ func multiplex(w http.ResponseWriter, r *http.Request) {
 	// into memory up to maxBodySize so retries can recreate the body safely.
 	if getBody == nil {
 		bodyBytes, readErr = io.ReadAll(io.LimitReader(r.Body, maxBodySize+1))
-			if err := r.Body.Close(); err != nil {
-				logWarn("Failed to close request body after read: %v", err)
-			}
+		if err := r.Body.Close(); err != nil {
+			logWarn("Failed to close request body after read: %v", err)
+		}
 		if readErr != nil {
 			logError("Error reading request body: %v", readErr)
 			writeJSONError(w, "Failed to read request body", http.StatusBadRequest)
@@ -439,6 +459,9 @@ func multiplex(w http.ResponseWriter, r *http.Request) {
 			logError("Request body size exceeds limit (%d bytes read)", len(bodyBytes))
 			writeJSONError(w, "Payload too large", http.StatusRequestEntityTooLarge)
 			return
+		}
+		if metricsEnabled {
+			bodySize.WithLabelValues(r.URL.Path).Observe(float64(len(bodyBytes)))
 		}
 
 		// Provide a GetBody closure for retries
@@ -454,9 +477,9 @@ func multiplex(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		bodyBytes, readErr = io.ReadAll(io.LimitReader(bodyReader, maxBodySize+1))
-			if err := bodyReader.Close(); err != nil {
-				logWarn("Failed to close body reader after size check: %v", err)
-			}
+		if err := bodyReader.Close(); err != nil {
+			logWarn("Failed to close body reader after size check: %v", err)
+		}
 
 		if readErr != nil {
 			logError("Error reading body for size check: %v", readErr)
@@ -648,7 +671,7 @@ func sendRequest(ctx context.Context, client *http.Client, target string, origin
 
 	if response == nil {
 		resp.Status = http.StatusServiceUnavailable
-		resp.Error = fmt.Sprintf("Request failed after %d attempts (no response received)", attempts+1)
+		resp.Error = fmt.Sprintf("Request failed after %d attempts (no response received)", attempts)
 		logErrorWithContext(map[string]string{"target": target}, "%s", resp.Error)
 		return resp
 	}

--- a/fanout.go
+++ b/fanout.go
@@ -577,7 +577,7 @@ func sendRequest(ctx context.Context, client *http.Client, target string, origin
 			req.Header.Set("X-Retry-Count", strconv.Itoa(attempts))
 		}
 
-		response, err = client.Do(req)
+		response, err = client.Do(req) // #nosec G704 -- target validated by caller
 
 		if err != nil {
 			if isRetryableError(err) && attempts < maxRetries {
@@ -701,7 +701,9 @@ func isRetryableError(err error) bool {
 }
 
 func addJitter(d time.Duration) time.Duration {
-	jitter := float64(d) * (0.8 + 0.4*rand.Float64())
+	// Non-crypto randomness is acceptable for backoff jitter.
+	// #nosec G404 -- math/rand is sufficient for jitter in retry backoff
+	jitter := float64(d) * (0.8 + 0.4*rand.Float64()) // #nosec G404
 	return time.Duration(jitter)
 }
 

--- a/fanout.go
+++ b/fanout.go
@@ -490,7 +490,6 @@ func sendRequest(ctx context.Context, client *http.Client, target string, origin
 		}
 	}()
 
-	var err error
 	var response *http.Response
 	attempts := 0
 	backoff := initialRetryBackoff
@@ -502,7 +501,7 @@ func sendRequest(ctx context.Context, client *http.Client, target string, origin
 			case <-ctx.Done():
 				resp.Status = http.StatusGatewayTimeout
 				resp.Error = fmt.Sprintf("Context cancelled during retry backoff: %v", ctx.Err())
-				logErrorWithContext(map[string]string{"target": target}, resp.Error)
+				logErrorWithContext(map[string]string{"target": target}, "%s", resp.Error)
 				return resp
 			}
 			backoff = min(backoff*2, maxRetryBackoff)
@@ -512,13 +511,18 @@ func sendRequest(ctx context.Context, client *http.Client, target string, origin
 		if len(preReadBody) > 0 && attempts == 0 {
 			bodyReader = io.NopCloser(bytes.NewReader(preReadBody))
 		} else {
-			var getBodyErr error
-			bodyReader, getBodyErr = getBody()
-			if getBodyErr != nil {
-				resp.Status = http.StatusInternalServerError
-				resp.Error = fmt.Sprintf("Failed to get request body for attempt %d: %v", attempts+1, getBodyErr)
-				logErrorWithContext(map[string]string{"target": target}, resp.Error)
-				return resp
+			if getBody == nil {
+				// No GetBody available and no preReadBody: use nil body (safe for methods without body)
+				bodyReader = nil
+			} else {
+				var getBodyErr error
+				bodyReader, getBodyErr = getBody()
+				if getBodyErr != nil {
+					resp.Status = http.StatusInternalServerError
+					resp.Error = fmt.Sprintf("Failed to get request body for attempt %d: %v", attempts+1, getBodyErr)
+					logErrorWithContext(map[string]string{"target": target}, "%s", resp.Error)
+					return resp
+				}
 			}
 		}
 
@@ -527,7 +531,7 @@ func sendRequest(ctx context.Context, client *http.Client, target string, origin
 			resp.Status = http.StatusInternalServerError
 			resp.Error = fmt.Sprintf("Failed to create request: %v", err)
 			bodyReader.Close()
-			logErrorWithContext(map[string]string{"target": target}, resp.Error)
+			logErrorWithContext(map[string]string{"target": target}, "%s", resp.Error)
 			return resp
 		}
 
@@ -555,13 +559,18 @@ func sendRequest(ctx context.Context, client *http.Client, target string, origin
 					},
 					"Network error, retrying request",
 				)
+				// If a response object was returned alongside the error, close it and discard
+				if response != nil {
+					response.Body.Close()
+					response = nil
+				}
 				attempts++
 				continue
 			}
 
 			resp.Status = http.StatusServiceUnavailable
 			resp.Error = fmt.Sprintf("Request failed after %d attempts: %v", attempts+1, err)
-			logErrorWithContext(map[string]string{"target": target}, resp.Error)
+			logErrorWithContext(map[string]string{"target": target}, "%s", resp.Error)
 			return resp
 		}
 
@@ -586,7 +595,7 @@ func sendRequest(ctx context.Context, client *http.Client, target string, origin
 	if response == nil {
 		resp.Status = http.StatusServiceUnavailable
 		resp.Error = fmt.Sprintf("Request failed after %d attempts (no response received)", attempts+1)
-		logErrorWithContext(map[string]string{"target": target}, resp.Error)
+		logErrorWithContext(map[string]string{"target": target}, "%s", resp.Error)
 		return resp
 	}
 	defer response.Body.Close()
@@ -595,7 +604,7 @@ func sendRequest(ctx context.Context, client *http.Client, target string, origin
 	if readErr != nil {
 		resp.Status = http.StatusInternalServerError
 		resp.Error = fmt.Sprintf("Failed to read response body: %v", readErr)
-		logErrorWithContext(map[string]string{"target": target, "status": strconv.Itoa(response.StatusCode)}, resp.Error)
+		logErrorWithContext(map[string]string{"target": target, "status": strconv.Itoa(response.StatusCode)}, "%s", resp.Error)
 		if response.StatusCode != 0 {
 			resp.Status = response.StatusCode
 		}

--- a/fanout.go
+++ b/fanout.go
@@ -282,12 +282,20 @@ func init() {
 		maxRetries = defaultMaxRetries
 	}
 
-	// Cache TARGETS at startup to avoid per-request env reads.
+	// Cache TARGETS at startup, validating each entry is an absolute http/https URL.
 	if t := os.Getenv("TARGETS"); t != "" && t != "localonly" {
 		for _, u := range strings.Split(t, ",") {
-			if trimmed := strings.TrimSpace(u); trimmed != "" {
-				configuredTargets = append(configuredTargets, trimmed)
+			trimmed := strings.TrimSpace(u)
+			if trimmed == "" {
+				continue
 			}
+			parsed, err := url.Parse(trimmed)
+			if err != nil || !parsed.IsAbs() || parsed.Host == "" ||
+				(parsed.Scheme != "http" && parsed.Scheme != "https") {
+				log.Printf("WARNING: Skipping invalid target URL %q (must be absolute http/https with non-empty host)", trimmed)
+				continue
+			}
+			configuredTargets = append(configuredTargets, trimmed)
 		}
 	}
 
@@ -611,8 +619,8 @@ func sendRequest(ctx context.Context, client *http.Client, target string, origin
 			}
 		}
 
-		// target was validated by caller (must be absolute http/https with host). Suppress gosec SSRF warning.
-		// #nosec G704 -- validated target URL in multiplex
+		// target is validated as an absolute http/https URL in init() when configuredTargets is built.
+		// #nosec G107 -- validated target URL at startup
 		req, err := http.NewRequestWithContext(ctx, originalReq.Method, target, bodyReader)
 		if err != nil {
 			resp.Status = http.StatusInternalServerError
@@ -637,7 +645,7 @@ func sendRequest(ctx context.Context, client *http.Client, target string, origin
 			req.Header.Set("X-Retry-Count", strconv.Itoa(attempts))
 		}
 
-		response, err = client.Do(req) // #nosec G704 -- target validated by caller
+		response, err = client.Do(req) // #nosec G107 -- target validated at startup
 
 		if err != nil {
 			if isRetryableError(err) && attempts < maxRetries {
@@ -695,7 +703,9 @@ func sendRequest(ctx context.Context, client *http.Client, target string, origin
 	}
 	defer response.Body.Close()
 
-	respBody, readErr := io.ReadAll(io.LimitReader(response.Body, maxBodySize))
+	// Read one extra byte so we can distinguish an exact-maxBodySize response
+	// from a genuinely truncated one (io.LimitReader alone cannot tell the difference).
+	respBody, readErr := io.ReadAll(io.LimitReader(response.Body, maxBodySize+1))
 	if readErr != nil {
 		resp.Status = http.StatusInternalServerError
 		resp.Error = fmt.Sprintf("Failed to read response body: %v", readErr)
@@ -706,15 +716,15 @@ func sendRequest(ctx context.Context, client *http.Client, target string, origin
 		return resp
 	}
 
+	if int64(len(respBody)) > maxBodySize {
+		resp.Truncated = true
+		respBody = respBody[:maxBodySize]
+		logWarnWithContext(map[string]string{"target": target}, "Response body truncated at limit (%d bytes)", maxBodySize)
+	}
+
 	resp.Status = response.StatusCode
 	resp.Body = string(respBody)
 	resp.Attempts = attempts + 1
-
-	// Warn if the response body was silently capped at maxBodySize.
-	if int64(len(respBody)) == maxBodySize {
-		resp.Truncated = true
-		logWarnWithContext(map[string]string{"target": target}, "Response body truncated at limit (%d bytes)", maxBodySize)
-	}
 
 	logDebugWithContext(
 		map[string]string{
@@ -807,9 +817,14 @@ func main() {
 			if port == "" {
 				port = "8080"
 			}
+			hcClient := &http.Client{Timeout: 5 * time.Second}
 			// #nosec G107 -- localhost-only health probe, port sourced from env
-			resp, err := http.Get("http://localhost:" + port + "/health")
-			if err != nil || resp.StatusCode != http.StatusOK {
+			hcResp, err := hcClient.Get("http://localhost:" + port + "/health")
+			if err != nil {
+				os.Exit(1)
+			}
+			hcResp.Body.Close()
+			if hcResp.StatusCode != http.StatusOK {
 				os.Exit(1)
 			}
 			os.Exit(0)

--- a/fanout.go
+++ b/fanout.go
@@ -196,7 +196,13 @@ func init() {
 			log.Printf("Invalid MAX_BODY_SIZE '%s', using default: %v", sizeStr, err)
 			maxBodySize = defaultMaxBodySize
 		} else {
-			maxBodySize = int64(size)
+			// humanize.ParseBytes returns uint64; guard against overflow when converting to int64
+			if size > uint64(^uint64(0)>>1) {
+				log.Printf("MAX_BODY_SIZE '%s' too large, capping to default: %d", sizeStr, defaultMaxBodySize)
+				maxBodySize = defaultMaxBodySize
+			} else {
+				maxBodySize = int64(size)
+			}
 		}
 	}
 

--- a/fanout.go
+++ b/fanout.go
@@ -782,22 +782,40 @@ func writeJSONError(w http.ResponseWriter, message string, status int) {
 	if err := writeJSON(w, map[string]string{"error": message}); err != nil {
 		logError("Failed to write JSON error response: %v", err)
 	}
-
 }
 
 func versionHandler(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	if err := writeJSON(w, map[string]string{
-			"version":    Version,
-			"git_commit": GitCommit,
-			"build_time": BuildTime,
-		}); err != nil {
-			logError("Failed to write version response: %v", err)
-		}
-
+		"version":    Version,
+		"git_commit": GitCommit,
+		"build_time": BuildTime,
+	}); err != nil {
+		logError("Failed to write version response: %v", err)
+	}
 }
 
 func main() {
+	// Handle CLI flags before any server setup so they run cleanly without side effects.
+	if len(os.Args) > 1 {
+		switch os.Args[1] {
+		case "-version":
+			fmt.Printf("FanOut %s (commit: %s, built: %s)\n", Version, GitCommit, BuildTime)
+			os.Exit(0)
+		case "-healthcheck":
+			port := os.Getenv("PORT")
+			if port == "" {
+				port = "8080"
+			}
+			// #nosec G107 -- localhost-only health probe, port sourced from env
+			resp, err := http.Get("http://localhost:" + port + "/health")
+			if err != nil || resp.StatusCode != http.StatusOK {
+				os.Exit(1)
+			}
+			os.Exit(0)
+		}
+	}
+
 	log.SetOutput(os.Stdout)
 
 	logInfo("Starting FanOut service version %s (commit: %s, built: %s)", Version, GitCommit, BuildTime)
@@ -808,19 +826,12 @@ func main() {
 		http.HandleFunc(endpointPath, echoHandler)
 		logInfo("Running in ECHO MODE (Endpoint: %s)", endpointPath)
 	} else {
-		targetList := strings.Split(targets, ",")
-		validTargets := 0
-		for _, t := range targetList {
-			if strings.TrimSpace(t) != "" {
-				validTargets++
-			}
-		}
-		if validTargets == 0 {
+		if len(configuredTargets) == 0 {
 			logError("FATAL: No valid target URLs configured in TARGETS environment variable.")
 			os.Exit(1)
 		}
 		http.HandleFunc(endpointPath, multiplex)
-		logInfo("Running in MULTIPLEX MODE (Endpoint: %s) with %d targets", endpointPath, validTargets)
+		logInfo("Running in MULTIPLEX MODE (Endpoint: %s) with %d targets", endpointPath, len(configuredTargets))
 	}
 
 	http.HandleFunc("/health", healthCheck)
@@ -837,11 +848,6 @@ func main() {
 	port := os.Getenv("PORT")
 	if port == "" {
 		port = "8080"
-	}
-
-	if len(os.Args) > 1 && os.Args[1] == "-version" {
-		fmt.Printf("FanOut %s (commit: %s, built: %s)\n", Version, GitCommit, BuildTime)
-		os.Exit(0)
 	}
 
 	var displayMaxBody uint64

--- a/fanout.go
+++ b/fanout.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"math"
 	"math/rand"
 	"net"
 	"net/http"
@@ -779,9 +780,15 @@ func main() {
 		os.Exit(0)
 	}
 
+	var displayMaxBody uint64
+	if maxBodySize < 0 {
+		displayMaxBody = 0
+	} else {
+		displayMaxBody = uint64(maxBodySize)
+	}
 	logInfo("Server starting on :%s (Max body: %s, Request Timeout: %s, Client Timeout: %s, Max Retries: %d)",
 		port,
-		humanize.Bytes(uint64(maxBodySize)),
+		humanize.Bytes(displayMaxBody),
 		requestTimeout,
 		clientTimeout,
 		maxRetries)

--- a/fanout.go
+++ b/fanout.go
@@ -557,6 +557,8 @@ func sendRequest(ctx context.Context, client *http.Client, target string, origin
 			}
 		}
 
+		// target was validated by caller (must be absolute http/https with host). Suppress gosec SSRF warning.
+		// #nosec G704 -- validated target URL in multiplex
 		req, err := http.NewRequestWithContext(ctx, originalReq.Method, target, bodyReader)
 		if err != nil {
 			resp.Status = http.StatusInternalServerError
@@ -799,5 +801,17 @@ func main() {
 		requestTimeout,
 		clientTimeout,
 		maxRetries)
-	log.Fatal(http.ListenAndServe(":"+port, nil))
+
+	// Use http.Server with explicit timeouts to satisfy gosec G114 recommendations
+	server := &http.Server{
+		Addr:         ":" + port,
+		ReadTimeout:  requestTimeout + 5*time.Second,
+		WriteTimeout: requestTimeout + 5*time.Second,
+		IdleTimeout:  60 * time.Second,
+	}
+	// Start server and log errors consistently
+	if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+		logError("Server error: %v", err)
+		os.Exit(1)
+	}
 }

--- a/fanout.go
+++ b/fanout.go
@@ -6,6 +6,7 @@ package main
 import (
 	"bytes"
 	"context"
+	cryptorand "crypto/rand"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -413,13 +414,26 @@ func healthCheck(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+// Response holds the result of a single fan-out request to one target.
+// Latency is expressed in seconds as a float64 for easy consumption.
 type Response struct {
-	Target   string        `json:"target"`
-	Status   int           `json:"status"`
-	Body     string        `json:"body,omitempty"`
-	Error    string        `json:"error,omitempty"`
-	Latency  time.Duration `json:"latency"`
-	Attempts int           `json:"attempts,omitempty"`
+	Target    string  `json:"target"`
+	Status    int     `json:"status"`
+	Body      string  `json:"body,omitempty"`
+	Error     string  `json:"error,omitempty"`
+	Latency   float64 `json:"latency_seconds"`
+	Attempts  int     `json:"attempts,omitempty"`
+	Truncated bool    `json:"truncated,omitempty"`
+}
+
+// generateRequestID returns a UUID v4-like hex string using crypto/rand.
+// Falls back to a timestamp string if the random source fails.
+func generateRequestID() string {
+	b := make([]byte, 16)
+	if _, err := cryptorand.Read(b); err != nil {
+		return fmt.Sprintf("%d", time.Now().UnixNano())
+	}
+	return fmt.Sprintf("%08x-%04x-%04x-%04x-%012x", b[0:4], b[4:6], b[6:8], b[8:10], b[10:])
 }
 
 func multiplex(w http.ResponseWriter, r *http.Request) {
@@ -437,6 +451,14 @@ func multiplex(w http.ResponseWriter, r *http.Request) {
 		writeJSONError(w, "Payload too large", http.StatusRequestEntityTooLarge)
 		return
 	}
+
+	// Set or generate X-Request-ID for correlation across all fan-out targets.
+	requestID := r.Header.Get("X-Request-ID")
+	if requestID == "" {
+		requestID = generateRequestID()
+		r.Header.Set("X-Request-ID", requestID)
+	}
+	w.Header().Set("X-Request-ID", requestID)
 
 	getBody := r.GetBody
 
@@ -491,38 +513,34 @@ func multiplex(w http.ResponseWriter, r *http.Request) {
 			writeJSONError(w, "Payload too large", http.StatusRequestEntityTooLarge)
 			return
 		}
+		if metricsEnabled {
+			bodySize.WithLabelValues(r.URL.Path).Observe(float64(len(bodyBytes)))
+		}
 	} else {
 		if metricsEnabled {
 			bodySize.WithLabelValues(r.URL.Path).Observe(float64(r.ContentLength))
 		}
 	}
 
-	targetsEnv := os.Getenv("TARGETS")
-	targets := strings.Split(targetsEnv, ",")
-	if len(targets) == 0 || (len(targets) == 1 && targets[0] == "") {
+	if len(configuredTargets) == 0 {
 		logError("No targets configured (TARGETS env var is empty or not set)")
 		writeJSONError(w, "No targets configured", http.StatusServiceUnavailable)
 		return
 	}
 
-	responses := make([]Response, 0, len(targets))
+	responses := make([]Response, 0, len(configuredTargets))
 	var wg sync.WaitGroup
-	respChan := make(chan Response, len(targets))
+	respChan := make(chan Response, len(configuredTargets))
 
-	for _, target := range targets {
-		targetURL := strings.TrimSpace(target)
-		if targetURL == "" {
-			logWarn("Skipping empty target URL found in TARGETS list")
-			continue
-		}
+	for _, target := range configuredTargets {
 		wg.Add(1)
 		go func(target string) {
 			defer wg.Done()
 			start := time.Now()
 			resp := sendRequest(ctx, httpClient, target, r, getBody, bodyBytes)
-			resp.Latency = time.Since(start)
+			resp.Latency = time.Since(start).Seconds()
 			respChan <- resp
-		}(targetURL)
+		}(target)
 	}
 
 	go func() {
@@ -692,12 +710,18 @@ func sendRequest(ctx context.Context, client *http.Client, target string, origin
 	resp.Body = string(respBody)
 	resp.Attempts = attempts + 1
 
+	// Warn if the response body was silently capped at maxBodySize.
+	if int64(len(respBody)) == maxBodySize {
+		resp.Truncated = true
+		logWarnWithContext(map[string]string{"target": target}, "Response body truncated at limit (%d bytes)", maxBodySize)
+	}
+
 	logDebugWithContext(
 		map[string]string{
 			"target":   target,
 			"status":   strconv.Itoa(resp.Status),
 			"attempts": strconv.Itoa(resp.Attempts),
-			"latency":  resp.Latency.String(),
+			"latency":  time.Since(startTime).String(),
 		},
 		"Request completed successfully",
 	)

--- a/fanout.go
+++ b/fanout.go
@@ -11,7 +11,6 @@ import (
 	"fmt"
 	"io"
 	"log"
-	"math"
 	"math/rand"
 	"net"
 	"net/http"

--- a/fanout.go
+++ b/fanout.go
@@ -193,12 +193,12 @@ func init() {
 	} else {
 		size, err := humanize.ParseBytes(sizeStr)
 		if err != nil {
-			log.Printf("Invalid MAX_BODY_SIZE, using default: %v", sizeStr, err)
+			log.Printf("Invalid MAX_BODY_SIZE, using default")
 			maxBodySize = defaultMaxBodySize
 		} else {
 			// humanize.ParseBytes returns uint64; guard against overflow when converting to int64
 			if size > uint64(^uint64(0)>>1) {
-				log.Printf("MAX_BODY_SIZE too large, capping to default: %d", sizeStr, defaultMaxBodySize)
+				log.Printf("MAX_BODY_SIZE too large, capping to default: %d", defaultMaxBodySize)
 				maxBodySize = defaultMaxBodySize
 			} else {
 				maxBodySize = int64(size)
@@ -208,7 +208,7 @@ func init() {
 
 	if timeout := os.Getenv("REQUEST_TIMEOUT"); timeout != "" {
 		if d, err := time.ParseDuration(timeout); err != nil {
-			log.Printf("Invalid REQUEST_TIMEOUT, using default: %v", timeout, err)
+			log.Printf("Invalid REQUEST_TIMEOUT, using default")
 			requestTimeout = defaultRequestTimeout
 		} else {
 			requestTimeout = d
@@ -219,7 +219,7 @@ func init() {
 
 	if timeout := os.Getenv("CLIENT_TIMEOUT"); timeout != "" {
 		if d, err := time.ParseDuration(timeout); err != nil {
-			log.Printf("Invalid CLIENT_TIMEOUT, using default: %v", timeout, err)
+			log.Printf("Invalid CLIENT_TIMEOUT, using default")
 			clientTimeout = defaultClientTimeout
 		} else {
 			clientTimeout = d
@@ -263,7 +263,7 @@ func init() {
 
 	if retriesStr := os.Getenv("MAX_RETRIES"); retriesStr != "" {
 		if retries, err := strconv.Atoi(retriesStr); err != nil || retries < 0 {
-			log.Printf("Invalid MAX_RETRIES, using default: %v", retriesStr, err)
+			log.Printf("Invalid MAX_RETRIES, using default")
 			maxRetries = defaultMaxRetries
 		} else {
 			maxRetries = retries
@@ -576,7 +576,11 @@ func sendRequest(ctx context.Context, client *http.Client, target string, origin
 		if err != nil {
 			resp.Status = http.StatusInternalServerError
 			resp.Error = fmt.Sprintf("Failed to create request: %v", err)
-			bodyReader.Close()
+			if bodyReader != nil {
+				if cerr := bodyReader.Close(); cerr != nil {
+					logWarn("Failed to close body reader after request creation: %v", cerr)
+				}
+			}
 			logErrorWithContext(map[string]string{"target": target}, "%s", resp.Error)
 			return resp
 		}
@@ -607,7 +611,9 @@ func sendRequest(ctx context.Context, client *http.Client, target string, origin
 				)
 				// If a response object was returned alongside the error, close it and discard
 				if response != nil {
-					response.Body.Close()
+					if cerr := response.Body.Close(); cerr != nil {
+						logWarn("Failed to close response body after network error: %v", cerr)
+					}
 					response = nil
 				}
 				attempts++
@@ -630,7 +636,9 @@ func sendRequest(ctx context.Context, client *http.Client, target string, origin
 				},
 				"Server error status, retrying request",
 			)
-			response.Body.Close()
+			if cerr := response.Body.Close(); cerr != nil {
+				logWarn("Failed to close response body after server error: %v", cerr)
+			}
 			attempts++
 			continue
 		}
@@ -743,16 +751,22 @@ func writeJSON(w http.ResponseWriter, v interface{}) error {
 func writeJSONError(w http.ResponseWriter, message string, status int) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)
-	writeJSON(w, map[string]string{"error": message})
+	if err := writeJSON(w, map[string]string{"error": message}); err != nil {
+		logError("Failed to write JSON error response: %v", err)
+	}
+
 }
 
 func versionHandler(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
-	writeJSON(w, map[string]string{
-		"version":    Version,
-		"git_commit": GitCommit,
-		"build_time": BuildTime,
-	})
+	if err := writeJSON(w, map[string]string{
+			"version":    Version,
+			"git_commit": GitCommit,
+			"build_time": BuildTime,
+		}); err != nil {
+			logError("Failed to write version response: %v", err)
+		}
+
 }
 
 func main() {

--- a/fanout_additional_test.go
+++ b/fanout_additional_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"testing"
 )
 
@@ -18,10 +17,10 @@ func TestMultiplexNoGetBody(t *testing.T) {
 	}))
 	defer server.Close()
 
-	// Set TARGETS to the mock server
-	origTargets := os.Getenv("TARGETS")
-	defer os.Setenv("TARGETS", origTargets)
-	os.Setenv("TARGETS", server.URL)
+	// Set configuredTargets directly (TARGETS env var is cached at init time, not per-request)
+	origTargets := configuredTargets
+	defer func() { configuredTargets = origTargets }()
+	configuredTargets = []string{server.URL}
 
 	// Create a request WITHOUT GetBody (http.NewRequest leaves GetBody nil)
 	body := []byte("hello")

--- a/fanout_additional_test.go
+++ b/fanout_additional_test.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+)
+
+// TestMultiplexNoGetBody ensures multiplex can handle requests without GetBody
+func TestMultiplexNoGetBody(t *testing.T) {
+	// Start a mock target server
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("ok"))
+	}))
+	defer server.Close()
+
+	// Set TARGETS to the mock server
+	origTargets := os.Getenv("TARGETS")
+	defer os.Setenv("TARGETS", origTargets)
+	os.Setenv("TARGETS", server.URL)
+
+	// Create a request WITHOUT GetBody (http.NewRequest leaves GetBody nil)
+	body := []byte("hello")
+	req, err := http.NewRequest("POST", "/fanout", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("Failed to create request: %v", err)
+	}
+	req.Header.Set("Content-Type", "text/plain")
+
+	w := httptest.NewRecorder()
+	// Call multiplex handler directly
+	multiplex(w, req)
+
+	resp := w.Result()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("Expected 200 OK from multiplex, got %d", resp.StatusCode)
+	}
+	var results []Response
+	if err := json.NewDecoder(resp.Body).Decode(&results); err != nil {
+		t.Fatalf("Failed to decode multiplex response: %v", err)
+	}
+	if len(results) == 0 || results[0].Status != http.StatusOK {
+		t.Fatalf("Unexpected target response: %v", results)
+	}
+}
+
+// fakeNetErr implements net.Error for testing
+type fakeNetErr struct{ msg string }
+
+func (f fakeNetErr) Error() string   { return f.msg }
+func (f fakeNetErr) Timeout() bool   { return true }
+func (f fakeNetErr) Temporary() bool { return false }
+
+func TestIsRetryableError_NetError(t *testing.T) {
+	err := fakeNetErr{"timeout"}
+	if !isRetryableError(err) {
+		t.Errorf("expected fakeNetErr to be retryable")
+	}
+}

--- a/fanout_additional_test.go
+++ b/fanout_additional_test.go
@@ -1,10 +1,11 @@
 package main
 
 import (
-	"bytes"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
@@ -22,9 +23,10 @@ func TestMultiplexNoGetBody(t *testing.T) {
 	defer func() { configuredTargets = origTargets }()
 	configuredTargets = []string{server.URL}
 
-	// Create a request WITHOUT GetBody (http.NewRequest leaves GetBody nil)
-	body := []byte("hello")
-	req, err := http.NewRequest("POST", "/fanout", bytes.NewReader(body))
+	// http.NewRequest sets GetBody automatically for *bytes.Reader / *bytes.Buffer.
+	// Wrap in io.NopCloser so the body is a plain io.ReadCloser and GetBody stays nil,
+	// which forces multiplex into the pre-read code path.
+	req, err := http.NewRequest("POST", "/fanout", io.NopCloser(strings.NewReader("hello")))
 	if err != nil {
 		t.Fatalf("Failed to create request: %v", err)
 	}

--- a/fanout_test.go
+++ b/fanout_test.go
@@ -9,7 +9,6 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"reflect"
 	"strings"
 	"testing"
@@ -160,8 +159,8 @@ func TestWriteJSON(t *testing.T) {
 				Body:     "OK",
 				Attempts: 0, // Due to omitempty tag, this won't appear in JSON when 0
 			},
-			// Updated expected value - removed attempts since it has omitempty tag
-			expected: `{"target":"http://example.com","status":200,"body":"OK","latency":0}`,
+			// Updated expected value - removed attempts since it has omitempty tag; latency_seconds is float64
+			expected: `{"target":"http://example.com","status":200,"body":"OK","latency_seconds":0}`,
 		},
 	}
 
@@ -266,17 +265,16 @@ func TestHealthCheck(t *testing.T) {
 
 // TestEchoHandlerSimpleMode tests the echo handler in simple mode
 func TestEchoHandlerSimpleMode(t *testing.T) {
-	// Save and restore original env vars
-	originalHeader := os.Getenv("ECHO_MODE_HEADER")
-	originalResponse := os.Getenv("ECHO_MODE_RESPONSE")
+	// Save and restore cached echo mode vars (env vars are read at init time, not per-request)
+	origHeader := echoModeHeader
+	origResponse := echoModeResponse
 	defer func() {
-		os.Setenv("ECHO_MODE_HEADER", originalHeader)
-		os.Setenv("ECHO_MODE_RESPONSE", originalResponse)
+		echoModeHeader = origHeader
+		echoModeResponse = origResponse
 	}()
 
-	// Set environment for this test
-	os.Setenv("ECHO_MODE_HEADER", "false")
-	os.Setenv("ECHO_MODE_RESPONSE", "simple")
+	echoModeHeader = false
+	echoModeResponse = "simple"
 
 	// Create a request with a test body
 	body := []byte(`{"test":"data"}`)
@@ -308,17 +306,16 @@ func TestEchoHandlerSimpleMode(t *testing.T) {
 
 // TestEchoHandlerFullMode tests the echo handler in full mode
 func TestEchoHandlerFullMode(t *testing.T) {
-	// Save and restore original env vars
-	originalHeader := os.Getenv("ECHO_MODE_HEADER")
-	originalResponse := os.Getenv("ECHO_MODE_RESPONSE")
+	// Save and restore cached echo mode vars (env vars are read at init time, not per-request)
+	origHeader := echoModeHeader
+	origResponse := echoModeResponse
 	defer func() {
-		os.Setenv("ECHO_MODE_HEADER", originalHeader)
-		os.Setenv("ECHO_MODE_RESPONSE", originalResponse)
+		echoModeHeader = origHeader
+		echoModeResponse = origResponse
 	}()
 
-	// Set environment for this test
-	os.Setenv("ECHO_MODE_HEADER", "true")
-	os.Setenv("ECHO_MODE_RESPONSE", "full")
+	echoModeHeader = true
+	echoModeResponse = "full"
 
 	// Create a request with a test body
 	body := []byte(`{"test":"data"}`)
@@ -383,7 +380,9 @@ func TestSendRequest(t *testing.T) {
 		t.Fatalf("Failed to create request: %v", err)
 	}
 
-	// Set app-level retry count for test
+	// Set app-level retry count for test (restored on exit)
+	origMaxRetries := maxRetries
+	defer func() { maxRetries = origMaxRetries }()
 	maxRetries = 2
 
 	// Call sendRequest with mock server URL
@@ -416,7 +415,9 @@ func TestSendRequestNetworkError(t *testing.T) {
 		t.Fatalf("Failed to create request: %v", err)
 	}
 
-	// Set app-level retry count for test
+	// Set app-level retry count for test (restored on exit)
+	origMaxRetries := maxRetries
+	defer func() { maxRetries = origMaxRetries }()
 	maxRetries = 1
 
 	// Call sendRequest with a non-existent endpoint (will cause error)

--- a/fanout_test.go
+++ b/fanout_test.go
@@ -420,7 +420,7 @@ func TestSendRequestNetworkError(t *testing.T) {
 	maxRetries = 1
 
 	// Call sendRequest with a non-existent endpoint (will cause error)
-	resp := sendRequest(context.Background(), client, "http://nonexistent.example", req, req.GetBody, nil)
+	resp := sendRequest(context.Background(), client, "http://127.0.0.1:1", req, req.GetBody, nil)
 
 	// Verify response reports an error
 	if resp.Status != http.StatusServiceUnavailable {


### PR DESCRIPTION
## Summary

Full audit pass addressing 20 issues found across correctness, metrics, hygiene, CI, and missing features.

- **fix: -healthcheck flag** — container healthcheck was broken; `/fanout -healthcheck` was not handled and always exited 1 (tried to bind an in-use port). Now performs an HTTP GET to `/health` and exits 0/1 accordingly.
- **fix: deprecated APIs** — remove `rand.Seed` (no-op since Go 1.20), `min()` func that shadowed the Go 1.21 built-in, and `net.Error.Temporary()` calls deprecated since Go 1.18.
- **fix: response body truncation** — `io.LimitReader` was silently capping response bodies at `maxBodySize` with no indication. Now sets `truncated: true` on the `Response` and emits a WARN log.
- **fix: latency always 0 in debug log** — `sendRequest` logged `resp.Latency` which is set by the caller *after* the function returns; replaced with `time.Since(startTime)`.
- **fix: spurious `WriteHeader(500)` in `writeJSON`** — headers are already flushed when the encoder fails mid-write; the call was a no-op generating noise.
- **feat: `X-Request-ID` correlation** — generate a `crypto/rand` UUID-like ID if absent, forward to all targets (via existing `cloneHeaders`), echo on the fan-out response.
- **feat: `latency_seconds` as `float64`** — `Response.Latency` was `time.Duration` (raw int64 nanoseconds in JSON, undocumented unit). Now `float64` seconds with JSON key `latency_seconds`.
- **perf: cache startup config** — `TARGETS` and `ECHO_MODE_*` env vars were read and parsed on every single request via `os.Getenv`/`strings.Split`; now parsed once in `init()`.
- **fix: `bodySize` metric** — only observed when `ContentLength` was known; now recorded for all pre-read body paths.
- **fix: log noise** — sensitive-header log demoted from WARN→DEBUG (fires on every request with an `Authorization` header), log context keys sorted for deterministic output.
- **ci: lint/vet gate** — `gofmt -l . || true; go vet ./... || true` swallowed all failures; now fails the step on violations.
- **ci: gosec in binary-release** — security scan was only run in the Docker CI workflow, not before publishing binaries.
- **test: adapt for cached config** — tests that set env vars at runtime updated to set the package-level cached vars directly with `defer` restore; `maxRetries` global state restored in retry tests.

## Test Plan

- [x] `docker run --rm -v $(pwd):/src -w /src golang:1.24 go test -v -race ./...` — all 15 tests pass
- [x] `gofmt -l .` — no output (clean)
- [x] `go vet ./...` — clean
- [ ] Verify container healthcheck: `docker build . && docker run --rm <image> /fanout -healthcheck` should exit 0 once server is running
- [ ] Verify `X-Request-ID` is echoed in fan-out response headers
- [ ] Verify `latency_seconds` is a float in the JSON response array

🤖 Generated with [Claude Code](https://claude.ai/code)